### PR TITLE
improve code

### DIFF
--- a/src/eibclient.c
+++ b/src/eibclient.c
@@ -25,6 +25,7 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 #include <stdlib.h>
+#include <string.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <sys/socket.h>

--- a/src/linknx.cpp
+++ b/src/linknx.cpp
@@ -136,7 +136,7 @@ void die (const char *msg, ...)
     if (errno)
         printf (": %s\n", strerror (errno));
     else
-        printf ("\n", strerror (errno));
+        printf ("\n");
     exit (1);
 }
 


### PR DESCRIPTION
Fix a printf statement error in src/linknx.cpp
Add a missing string.h needed by some platforms in src/eibclient.
Signed-off-by: Othmar Truniger <github@truniger.ch>