### PR TITLE
Added unbuffered read option

### DIFF
--- a/src/objectcontroller.cpp
+++ b/src/objectcontroller.cpp
@@ -230,6 +230,12 @@ ObjectValue* Object::get()
     return getObjectValue();
 }
 
+void Object::reset_init_m_if_stateless()
+{
+    if (flags_m & Stateless)
+        init_m = false;
+}
+
 void Object::importXml(ticpp::Element* pConfig)
 {
     std::string type = pConfig->GetAttribute("type");

--- a/src/objectcontroller.h
+++ b/src/objectcontroller.h
@@ -106,6 +106,7 @@ public:
     static eibaddr_t ReadAddr(const std::string& addr);
     static std::string WriteGroupAddr(eibaddr_t addr);
     static std::string WriteAddr(eibaddr_t addr);
+    void reset_init_m_if_stateless();
 protected:
     virtual bool set(ObjectValue* value) = 0;
     virtual bool set(double value) = 0;

--- a/src/xmlserver.cpp
+++ b/src/xmlserver.cpp
@@ -209,6 +209,7 @@ void ClientConnection::Run (pth_sem_t * stop1)
                     std::string id = pRead->GetAttribute("id");
                     Object* obj = ObjectController::instance()->getObject(id);
                     std::stringstream msg;
+                    obj->reset_init_m_if_stateless();
                     msg << "<read status='success'>" << obj->getValue() << "</read>" << std::endl;
                     obj->decRefCount();
                     debugStream("ClientConnection") << "SENDING MESSAGE:" << endlog << msg.str() << endlog << "END OF MESSAGE" << endlog;
@@ -229,6 +230,7 @@ void ClientConnection::Run (pth_sem_t * stop1)
                             {
                                 std::string id = pObjects->GetAttribute("id");
                                 Object* obj = ObjectController::instance()->getObject(id);
+                                obj->reset_init_m_if_stateless();
                                 pObjects->SetAttribute("value", obj->getValue());
                                 obj->decRefCount();
                             }


### PR DESCRIPTION
Added an option for unbuffered object value reads.

The decision depends on the object's "s"-flag in the linknx.conf.
If the object's "s" flag is not set, linknx will deliver a buffered value to the user without causing any bus activity (similar to previous behavior). On the other hand, if the "s" flag for the object is set, a bus read is triggered every time the value is queried.
