### PR TITLE
src/suncalc.cpp: fix build with gcc 6.x

### DIFF
--- a/src/suncalc.cpp
+++ b/src/suncalc.cpp
@@ -22,6 +22,8 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
+#include <cmath>
+
 #include "suncalc.h"
 #include "services.h"
 
@@ -44,7 +46,6 @@ Released to the public domain by Paul Schlyter, December 1992
 
 
 #include <stdio.h>
-#include <math.h>
 #include <time.h>
 #include <stdlib.h>
 #include <getopt.h>


### PR DESCRIPTION
src/suncalc.cpp currently includes <math.h>, but this causes a build
failure with gcc 6.x, and <cmath> should be used instead. The build
failure is:

/home/test/autobuild/run/instance-0/output/host/usr/arc-buildroot-linux-uclibc/include/c++/6.1.1/cmath:101:37: error: '__is_integer' was not declared in this scope
     typename __gnu_cxx::__enable_if<__is_integer<_Tp>::__value,
                                     ^~~~~~~~~~~~

Signed-off-by: Thomas Petazzoni thomas.petazzoni@free-electrons.com
