### PR TITLE
fix periodic task calculation over DST switch

### DIFF
--- a/src/timermanager.cpp
+++ b/src/timermanager.cpp
@@ -560,7 +560,7 @@ time_t PeriodicTask::findNext(time_t start, TimeSpec* next)
                 if (hour == -1)
                     timeinfo->tm_hour = 0;
                 timeinfo->tm_mday = mday;
-                mktime(timeinfo);
+                mktimeNoDst(timeinfo);
                 timeinfo->tm_mday = mday;
             }
         }


### PR DESCRIPTION
Signed-off-by: Othmar Truniger <github@truniger.ch>

Description:
this fixes a calculation error for periodic tasks when start time is before and target time is after DST switch in fall.

current lines 562-564 in timermanager.cpp fail calculation, for example:
calculating 00:00 of day 1 next month from today (13.10.2018 GMT+2) results in parameters min=0, hour=0, day=1, mon=11, DST=1, being changed to min=0, hour=23, day=31, mon=10, DST=0 by mktime. Now setting mday back to 1 in line 564 and setting time further down results as 01.10.2018 23:00 GMT+2 which is ealier than start time.