### PR TITLE
Link with libiconv if needed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,7 @@ AC_CHECK_HEADER(argp.h,,[AC_MSG_ERROR([argp_parse not found])])
 AC_SEARCH_LIBS(argp_parse,argp,,[AC_MSG_ERROR([argp_parse not found])])
 
 # Checks for libraries.
+AC_SEARCH_LIBS(libiconv_open,iconv)
 LIBCURL_CHECK_CONFIG([yes], [7.14.0])
 
 # Checks for header files.


### PR DESCRIPTION
Commit 2cc3a93dcf2703b3b418e0a99975f556354fb1b1 added an include to
iconv which can be provided by libiconv so search and link for it if
needed

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>