### PR TITLE
configure.ac: always define CPPUNIT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -145,8 +145,11 @@ if test x"$WITH_CPPUNIT" != xno; then
       AC_DEFINE([HAVE_CPPUNIT], [1], [cppunit])
       AC_SUBST(CPPUNIT_CFLAGS)
       AC_SUBST(CPPUNIT_LIBS)
-    ])
+      AM_CONDITIONAL([CPPUNIT], true)
+    ],[AM_CONDITIONAL([CPPUNIT], false)])
   fi
+else
+  AM_CONDITIONAL([CPPUNIT], false)
 fi
 
 dnl #########################################################################


### PR DESCRIPTION
Fixes:
 - autobuild.buildroot.org/results/4b042b7e18425690ec26b4977865516bedcb9edb

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>