### PR TITLE
Fix libiconv support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,18 +21,6 @@ matrix:
                   sources:
                       - ubuntu-toolchain-r-test
                   packages:
-                      - g++-4.9
-                      - libcppunit-dev
-                      - gettext
-          env:
-            - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9" 
-
-        - os: linux
-          addons:
-              apt:
-                  sources:
-                      - ubuntu-toolchain-r-test
-                  packages:
                       - g++-8
                       - libcppunit-dev
                       - gettext

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
                   packages:
                       - g++-6
                       - libcppunit-dev
+                      - gettext
           env:
             - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6" 
 
@@ -22,6 +23,7 @@ matrix:
                   packages:
                       - g++-4.9
                       - libcppunit-dev
+                      - gettext
           env:
             - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9" 
 
@@ -33,6 +35,7 @@ matrix:
                   packages:
                       - g++-8
                       - libcppunit-dev
+                      - gettext
           env:
             - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8" 
 

--- a/configure.ac
+++ b/configure.ac
@@ -10,12 +10,12 @@ PKG_CONFIG=`which pkg-config`
 AC_PROG_CXX
 AC_PROG_CC
 AC_PROG_RANLIB
+AM_ICONV
 AC_CHECK_PTHSEM(2.0.4,yes,yes,no)
 AC_CHECK_HEADER(argp.h,,[AC_MSG_ERROR([argp_parse not found])])
 AC_SEARCH_LIBS(argp_parse,argp,,[AC_MSG_ERROR([argp_parse not found])])
 
 # Checks for libraries.
-AC_SEARCH_LIBS(libiconv_open,iconv)
 LIBCURL_CHECK_CONFIG([yes], [7.14.0])
 
 # Checks for header files.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,5 +7,5 @@ B64_CFLAGS=
 B64_LIBS=
 endif
 AM_CPPFLAGS=-I$(top_srcdir)/include -I$(top_srcdir)/ticpp $(B64_CFLAGS) $(PTH_CPPFLAGS) $(LIBCURL_CPPFLAGS) $(LOG4CPP_CFLAGS) $(LUA_CFLAGS) $(MYSQL_CFLAGS) $(ESMTP_CFLAGS)
-linknx_LDADD=$(top_srcdir)/ticpp/libticpp.a $(B64_LIBS) $(PTH_LDFLAGS) $(PTH_LIBS) $(LIBCURL) $(LOG4CPP_LIBS) $(LUA_LIBS) $(MYSQL_LIBS) $(ESMTP_LIBS) -lm
+linknx_LDADD=$(top_srcdir)/ticpp/libticpp.a $(LIBICONV) $(B64_LIBS) $(PTH_LDFLAGS) $(PTH_LIBS) $(LIBCURL) $(LOG4CPP_LIBS) $(LUA_LIBS) $(MYSQL_LIBS) $(ESMTP_LIBS) -lm
 linknx_SOURCES=linknx.cpp logger.cpp ruleserver.cpp objectcontroller.cpp eibclient.c threads.cpp timermanager.cpp  persistentstorage.cpp xmlserver.cpp smsgateway.cpp emailgateway.cpp knxconnection.cpp services.cpp suncalc.cpp  luacondition.cpp ioport.cpp ruleserver.h objectcontroller.h threads.h timermanager.h persistentstorage.h xmlserver.h smsgateway.h emailgateway.h knxconnection.h services.h suncalc.h luacondition.h ioport.h logger.h

--- a/src/objectcontroller.cpp
+++ b/src/objectcontroller.cpp
@@ -2925,7 +2925,7 @@ std::string StringObjectValue::transcode(const std::string &source, const std::s
 	iconv_t conversionDescriptor = iconv_open((targetEncoding + "//TRANSLIT").c_str(), sourceEncoding.c_str());
 	char cSource[source.size()];
 	memcpy(cSource, source.c_str(), source.size() + 1);
-	char *sourceStart = &cSource[0];
+	ICONV_CONST char *sourceStart = &cSource[0];
 	size_t sourceLength = source.size();
 	const size_t targetLength = source.size() * 5; // Should be pretty enough even in worst cases.
 	char targetChars[targetLength];


### PR DESCRIPTION
Autotools provide AM_ICONV for this.

some libiconv implementations use const char for iconv. Check for it.