### PR TITLE
Fix issue #47

### DIFF
--- a/src/ruleserver.cpp
+++ b/src/ruleserver.cpp
@@ -2387,6 +2387,8 @@ std::string ActionList::getTriggerTypeToString(TriggerType trigger)
 			return "if-false";
 		case ActionList::OnFalse:
 			return "on-false";
+		default:
+			throw ticpp::Exception("Unsupported trigger type.");
 	}
 }
 

--- a/src/suncalc.cpp
+++ b/src/suncalc.cpp
@@ -491,6 +491,7 @@ void SolarTimeSpec::getDay(const tm &current, int &mday, int &mon, int &year, in
 		// Solar time has already been reached for the current day. Let's move
 		// to the next day that complies with constraints.
 		solarTime.tryIncreaseClosestGreaterFreeField(DateTime::Day);
+        solarTime.tryResolve(currentDate, DateTime::Year, DateTime::Day);
 	}
 	mday = solarTime.getDay();
 	mon = solarTime.getMonth();

--- a/src/suncalc.cpp
+++ b/src/suncalc.cpp
@@ -475,62 +475,62 @@ double SolarNoonTimeSpec::computeTime(double rise, double set) const
 
 void SolarTimeSpec::getDay(const tm &current, int &mday, int &mon, int &year, int &wdays) const
 {
-	TimeSpec::getDay(current, mday, mon, year, wdays);
+    TimeSpec::getDay(current, mday, mon, year, wdays);
 
-	DateTime currentDate(&current);
-	currentDate.setYear(year);
-	currentDate.setMonth(mon);
-	currentDate.setDay(mday);
-	int min, hour;
-	getTime(currentDate.getDay(), currentDate.getMonth(), currentDate.getYear(), min, hour);
-	DateTime solarTime(currentDate);
-	solarTime.setHour(hour);
-	solarTime.setMinute(min);
-	if (solarTime < currentDate)
-	{
-		// Solar time has already been reached for the current day. Let's move
-		// to the next day that complies with constraints.
-		solarTime.tryIncreaseClosestGreaterFreeField(DateTime::Day);
+    DateTime currentDate(&current);
+    currentDate.setYear(year);
+    currentDate.setMonth(mon);
+    currentDate.setDay(mday);
+    int min, hour;
+    getTime(currentDate.getDay(), currentDate.getMonth(), currentDate.getYear(), min, hour);
+    DateTime solarTime(currentDate);
+    solarTime.setHour(hour);
+    solarTime.setMinute(min);
+    if (solarTime < currentDate)
+    {
+        // Solar time has already been reached for the current day. Let's move
+        // to the next day that complies with constraints.
+        solarTime.tryIncreaseClosestGreaterFreeField(DateTime::Day);
         solarTime.tryResolve(currentDate, DateTime::Year, DateTime::Day);
-	}
-	mday = solarTime.getDay();
-	mon = solarTime.getMonth();
-	year = solarTime.getYear();
+    }
+    mday = solarTime.getDay();
+    mon = solarTime.getMonth();
+    year = solarTime.getYear();
 }
 
 void SolarTimeSpec::getTime(int mday, int mon, int year, int &min, int &hour) const
 {
-	TimeSpec::getTime(mday, mon, year, min, hour);
+    TimeSpec::getTime(mday, mon, year, min, hour);
 
     LocationInfo* params = Services::instance()->getLocationInfo();
     double lon, lat;
     params->getCoord(&lon, &lat);
 
-	// Get sunrise/sunset in GMT.
+    // Get sunrise/sunset in GMT.
     logger_m.infoStream() << "sun_rise_set date " << year+1900<< "-" << mon+1 << "-" << mday << endlog;
     double rise, set;
     int rs = suncalc::sun_rise_set( year+1900, mon+1, mday, lon, lat, &rise, &set );
 
     if (rs == 0)
     {
-		long tzOffset = params->getGmtOffset();
+        long tzOffset = params->getGmtOffset();
         double res = computeTime(rise, set);
         min = minutes(res + minutes((double)tzOffset/3600));
         hour = hours(res + (double)tzOffset/3600);
 
-		// At this point, min and hour are expressed with DST off. Fix local
-		// time.
-		struct tm dateTime;
-		dateTime.tm_year = year;
-		dateTime.tm_mon = mon;
-		dateTime.tm_mday = mday;
-		dateTime.tm_hour = hour;
-		dateTime.tm_min = min;
-		dateTime.tm_sec = 0;
-		dateTime.tm_isdst = 0; // 0 because by definition, the time is currently expressed as if DST was off. mktime is going to fix that.
-		mktime(&dateTime);
-		hour = dateTime.tm_hour;
-		min = dateTime.tm_min;
+        // At this point, min and hour are expressed with DST off. Fix local
+        // time.
+        struct tm dateTime;
+        dateTime.tm_year = year;
+        dateTime.tm_mon = mon;
+        dateTime.tm_mday = mday;
+        dateTime.tm_hour = hour;
+        dateTime.tm_min = min;
+        dateTime.tm_sec = 0;
+        dateTime.tm_isdst = 0; // 0 because by definition, the time is currently expressed as if DST was off. mktime is going to fix that.
+        mktime(&dateTime);
+        hour = dateTime.tm_hour;
+        min = dateTime.tm_min;
 
         logger_m.infoStream() << "sun_rise_set returned " << hour<< ":" <<min << endlog;
     }
@@ -585,19 +585,19 @@ bool SolarInfo::get(double res, int *min, int *hour)
             *hour = 0;
         }
 
-		// At this point, min and hour are expressed with DST off. Fix local
-		// time.
-		struct tm dateTime;
-		dateTime.tm_year = year_m;
-		dateTime.tm_mon = mon_m;
-		dateTime.tm_mday = mday_m;
-		dateTime.tm_hour = *hour;
-		dateTime.tm_min = *min;
-		dateTime.tm_sec = 0;
-		dateTime.tm_isdst = 0; // 0 because by definition, the time is currently expressed as if DST was off. mktime is going to fix that.
-		mktime(&dateTime);
-		*hour = dateTime.tm_hour;
-		*min = dateTime.tm_min;
+        // At this point, min and hour are expressed with DST off. Fix local
+        // time.
+        struct tm dateTime;
+        dateTime.tm_year = year_m;
+        dateTime.tm_mon = mon_m;
+        dateTime.tm_mday = mday_m;
+        dateTime.tm_hour = *hour;
+        dateTime.tm_min = *min;
+        dateTime.tm_sec = 0;
+        dateTime.tm_isdst = 0; // 0 because by definition, the time is currently expressed as if DST was off. mktime is going to fix that.
+        mktime(&dateTime);
+        *hour = dateTime.tm_hour;
+        *min = dateTime.tm_min;
         logger_m.infoStream() << "returned " << *hour<< ":" << *min << endlog;
     }
     else
@@ -639,11 +639,11 @@ void LocationInfo::exportXml(ticpp::Element* pConfig)
 
 LocationInfo::LocationInfo() : lon_m(0), lat_m(0)
 {
-	// Get any time as reference and compute the broken-down GMT time.
-	// Then reverse the computation by interpreting the broken-down time as
-	// local time. The result is the 
-	time_t ref = 0;
-	gmtOffset_m = -mktime(gmtime(&ref));
+    // Get any time as reference and compute the broken-down GMT time.
+    // Then reverse the computation by interpreting the broken-down time as
+    // local time. The result is the 
+    time_t ref = 0;
+    gmtOffset_m = -mktime(gmtime(&ref));
 }
 
 long LocationInfo::getGmtOffset()

--- a/src/suncalc.cpp
+++ b/src/suncalc.cpp
@@ -491,6 +491,8 @@ void SolarTimeSpec::getDay(const tm &current, int &mday, int &mon, int &year, in
         // Solar time has already been reached for the current day. Let's move
         // to the next day that complies with constraints.
         solarTime.tryIncreaseClosestGreaterFreeField(DateTime::Day);
+
+        // Fixes #47: avoids selecting the day after end of month (32nd of March, for instance) by reprojecting it onto the actual calendar.
         solarTime.tryResolve(currentDate, DateTime::Year, DateTime::Day);
     }
     mday = solarTime.getDay();

--- a/test/PeriodicTaskTest.cpp
+++ b/test/PeriodicTaskTest.cpp
@@ -39,6 +39,7 @@ class PeriodicTaskTest : public CppUnit::TestFixture, public ChangeListener
     CPPUNIT_TEST( testFindNextHourDstSunrise );
     CPPUNIT_TEST( testNegativeMinutes );
     CPPUNIT_TEST( testSunriseSpecificDay );
+    CPPUNIT_TEST( testFindNextSunsetWithMonthChange );
 //    CPPUNIT_TEST(  );
     
     CPPUNIT_TEST_SUITE_END();
@@ -788,6 +789,34 @@ public:
         CPPUNIT_ASSERT_EQUAL(8, timeinfo->tm_mday);
         CPPUNIT_ASSERT_EQUAL(10, timeinfo->tm_mon);
         CPPUNIT_ASSERT_EQUAL(118, timeinfo->tm_year);
+    }
+
+    void testFindNextSunsetWithMonthChange()
+    {
+        time_t next;
+        struct tm * timeinfo;
+        struct tm curtimeinfo;
+        time_t curtimeref;
+		Services::instance()->getLocationInfo()->setCoord(4.84, 45.76); // Near Lyon, France.
+        curtimeinfo.tm_hour = 21; // 21:00:00, after sunset for the current day.
+        curtimeinfo.tm_min = 0;
+        curtimeinfo.tm_sec = 0;
+        curtimeinfo.tm_mday = 31;
+        curtimeinfo.tm_mon = 2; // March
+        curtimeinfo.tm_year = 120; // 2020
+        curtimeinfo.tm_isdst = -1;
+        curtimeref = mktime(&curtimeinfo);
+        SunsetTimeSpec ts1;
+
+        next = task_m->callFindNext(curtimeref, &ts1);
+
+        CPPUNIT_ASSERT(next != 0);
+        timeinfo = localtime(&next);
+        CPPUNIT_ASSERT_EQUAL(58, timeinfo->tm_min);
+        CPPUNIT_ASSERT_EQUAL(19, timeinfo->tm_hour);
+        CPPUNIT_ASSERT_EQUAL(1, timeinfo->tm_mday);
+        CPPUNIT_ASSERT_EQUAL(3, timeinfo->tm_mon);
+        CPPUNIT_ASSERT_EQUAL(120, timeinfo->tm_year);
     }
 
     void testFindNextHourDstSunrise()

--- a/test/PeriodicTaskTest.cpp
+++ b/test/PeriodicTaskTest.cpp
@@ -812,8 +812,8 @@ public:
 
         CPPUNIT_ASSERT(next != 0);
         timeinfo = localtime(&next);
-        CPPUNIT_ASSERT_EQUAL(58, timeinfo->tm_min);
-        CPPUNIT_ASSERT_EQUAL(19, timeinfo->tm_hour);
+        CPPUNIT_ASSERT_EQUAL(9, timeinfo->tm_min);
+        CPPUNIT_ASSERT_EQUAL(20, timeinfo->tm_hour);
         CPPUNIT_ASSERT_EQUAL(1, timeinfo->tm_mday);
         CPPUNIT_ASSERT_EQUAL(3, timeinfo->tm_mon);
         CPPUNIT_ASSERT_EQUAL(120, timeinfo->tm_year);


### PR DESCRIPTION
Fixes #47 by ensuring day provided by SolarTimeSpec is always projected onto actual calendar, as day, month and year are always fully constrained by this type of time spec. The fact that the projection was not happening before caused the logic in PeriodicTask::findNext to fail as the reported scenario was making SolarTimeSpec to select March 32nd. PeriodicTask::findNext then failed to satisfy this impossible constraint.