### PR TITLE
fix cdefs.h for cross compile

### DIFF
--- a/include/eibclient.h
+++ b/include/eibclient.h
@@ -27,11 +27,12 @@
 #ifndef EIBCLIENT_H
 #define EIBCLIENT_H
 
-#include "sys/cdefs.h"
 #include "stdint.h"
 #include <pthsem.h>
 
-__BEGIN_DECLS;
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "eibloadresult.h"
 
@@ -705,5 +706,8 @@ BCU_LOAD_RESULT EIB_LoadImage (EIBConnection * con, const uint8_t * image,
  */
 int EIB_LoadImage_async (EIBConnection * con, const uint8_t * image, int len);
 
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
+
 #endif


### PR DESCRIPTION
Signed-off-by: Othmar Truniger <github@truniger.ch>

this change was requested by openwrt maintainer to support cross compilation with musl instead of glibc. musl does not contain cdefs.h. the same change was applied to knxd source by its developper.