### PR TITLE
Reworked the way logged value is passed to persistent storage

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -19,11 +19,11 @@ jobs:
     - name: install dependencies
       run: sudo apt install libcppunit-dev gettext
     - name: get pthsem
-      run: wget https://www.auto.tuwien.ac.at/~mkoegler/pth/pthsem_2.0.8.tar.gz
+      run: wget https://github.com/linknx/pthsem/archive/master.zip
     - name: extract pthsem
-      run: tar -zxf pthsem_2.0.8.tar.gz
+      run: unzip pthsem-master.zip
     - name: build pthsem
-      working-directory: pthsem-2.0.8
+      working-directory: pthsem-master
       run: ./configure && make && sudo make install
     - name: update libraries registry
       run: sudo ldconfig

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -21,7 +21,7 @@ jobs:
     - name: get pthsem
       run: wget https://github.com/linknx/pthsem/archive/master.zip
     - name: extract pthsem
-      run: unzip pthsem-master.zip
+      run: unzip master.zip
     - name: build pthsem
       working-directory: pthsem-master
       run: ./configure && make && sudo make install

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -19,7 +19,7 @@ jobs:
     - name: install dependencies
       run: sudo apt install libcppunit-dev gettext
     - name: get pthsem
-      run: wget https://www.auto.tuwien.ac.at/~mkoegler/debian/pool/main/p/pthsem/pthsem_2.0.8.tar.gz
+      run: wget https://www.auto.tuwien.ac.at/~mkoegler/pth/pthsem_2.0.8.tar.gz
     - name: extract pthsem
       run: tar -zxf pthsem_2.0.8.tar.gz
     - name: build pthsem

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
     - eval "${MATRIX_EVAL}"
 
 install:
-    - wget https://www.auto.tuwien.ac.at/~mkoegler/pth/pthsem_2.0.8.tar.gz
+    - wget http://www.auto.tuwien.ac.at/~mkoegler/pth/pthsem_2.0.8.tar.gz
     - tar -zxf pthsem_2.0.8.tar.gz
     - cd pthsem-2.0.8
     - ./configure && make && sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
     - eval "${MATRIX_EVAL}"
 
 install:
-    - wget https://www.auto.tuwien.ac.at/~mkoegler/debian/pool/main/p/pthsem/pthsem_2.0.8.tar.gz
+    - wget https://www.auto.tuwien.ac.at/~mkoegler/pth/pthsem_2.0.8.tar.gz
     - tar -zxf pthsem_2.0.8.tar.gz
     - cd pthsem-2.0.8
     - ./configure && make && sudo make install

--- a/src/objectcontroller.cpp
+++ b/src/objectcontroller.cpp
@@ -481,7 +481,7 @@ void Object::onUpdate()
             if (persist_m)
                 persistence->write(id_m, getValue());
             if (writeLog_m)
-                persistence->writelog(id_m, getValue());
+                persistence->writelog(id_m, *get());
         }
     }
 }
@@ -582,7 +582,7 @@ void SwitchingObjectValue::init(const std::string& value)
     }
 }
 
-std::string SwitchingObjectValue::toString()
+std::string SwitchingObjectValue::toString() const
 {
     return getValueString(value_m);
 }
@@ -684,7 +684,7 @@ void SwitchingControlObjectValue::init(const std::string& value)
     }
 }
 
-std::string SwitchingControlObjectValue::toString()
+std::string SwitchingControlObjectValue::toString() const
 {
     if (!control_m)
         return "no control";
@@ -915,7 +915,7 @@ DimmingObjectValue::DimmingObjectValue(const std::string& value)
     }
 }
 
-std::string DimmingObjectValue::toString()
+std::string DimmingObjectValue::toString() const
 {
     if (stepcode_m == 0)
         return "stop";
@@ -989,7 +989,7 @@ BlindsObjectValue::BlindsObjectValue(const std::string& value)
     }
 }
 
-std::string BlindsObjectValue::toString()
+std::string BlindsObjectValue::toString() const
 {
     if (stepcode_m == 0)
         return "stop";
@@ -1045,7 +1045,7 @@ TimeObjectValue::TimeObjectValue(const std::string& value) : wday_m(-1), hour_m(
     }
 }
 
-std::string TimeObjectValue::toString()
+std::string TimeObjectValue::toString() const
 {
     if (hour_m == -1)
         return "now";
@@ -1277,7 +1277,7 @@ DateObjectValue::DateObjectValue(const std::string& value) : day_m(-1), month_m(
     }
 }
 
-std::string DateObjectValue::toString()
+std::string DateObjectValue::toString() const
 {
     if (day_m == -1)
         return "now";
@@ -1521,7 +1521,7 @@ std::string ValueObjectValue::getPrecision()
     }
 }
 
-std::string ValueObjectValue::toString()
+std::string ValueObjectValue::toString() const
 {
     std::ostringstream out;
     out.precision(8);
@@ -1712,7 +1712,7 @@ ValueObject32Value::ValueObject32Value(const std::string& value)
     }
 }
 
-std::string ValueObject32Value::toString()
+std::string ValueObject32Value::toString() const
 {
     std::ostringstream out;
     out.precision(8);
@@ -1780,7 +1780,7 @@ UIntObjectValue::UIntObjectValue(const std::string& value)
     }
 }
 
-std::string UIntObjectValue::toString()
+std::string UIntObjectValue::toString() const
 {
     std::ostringstream out;
     out << value_m;
@@ -1904,7 +1904,7 @@ U8ObjectValue::U8ObjectValue(const std::string& value)
     }
 }
 
-std::string U8ObjectValue::toString()
+std::string U8ObjectValue::toString() const
 {
     std::ostringstream out;
     out << value_m;
@@ -1948,7 +1948,7 @@ ScalingObjectValue::ScalingObjectValue(const std::string& value)
     value_m = (int)(fvalue * 255 / 100);
 }
 
-std::string ScalingObjectValue::toString()
+std::string ScalingObjectValue::toString() const
 {
     std::ostringstream out;
     out.precision(3);
@@ -1993,7 +1993,7 @@ AngleObjectValue::AngleObjectValue(const std::string& value)
     value_m = ((int)(fvalue * 256 / 360)) % 256;
 }
 
-std::string AngleObjectValue::toString()
+std::string AngleObjectValue::toString() const
 {
     std::ostringstream out;
     out.precision(4);
@@ -2040,7 +2040,7 @@ HeatingModeObjectValue::HeatingModeObjectValue(const std::string& value)
     }
 }
 
-std::string HeatingModeObjectValue::toString()
+std::string HeatingModeObjectValue::toString() const
 {
     switch (value_m)
     {
@@ -2091,7 +2091,7 @@ Latin1CharObjectValue::Latin1CharObjectValue(const std::string& value)
     value_m = (int)chvalue;
 }
 
-std::string Latin1CharObjectValue::toString()
+std::string Latin1CharObjectValue::toString() const
 {
     std::ostringstream out;
     out << (unsigned char)value_m;
@@ -2135,7 +2135,7 @@ AsciiCharObjectValue::AsciiCharObjectValue(const std::string& value)
     value_m = (int)chvalue;
 }
 
-std::string AsciiCharObjectValue::toString()
+std::string AsciiCharObjectValue::toString() const
 {
     std::ostringstream out;
     out << (unsigned char)value_m;
@@ -2177,7 +2177,7 @@ U16ObjectValue::U16ObjectValue(const std::string& value)
     }
 }
 
-std::string U16ObjectValue::toString()
+std::string U16ObjectValue::toString() const
 {
     std::ostringstream out;
     out << value_m;
@@ -2235,7 +2235,7 @@ U32ObjectValue::U32ObjectValue(const std::string& value)
     }
 }
 
-std::string U32ObjectValue::toString()
+std::string U32ObjectValue::toString() const
 {
     std::ostringstream out;
     out << value_m;
@@ -2294,7 +2294,7 @@ RGBObjectValue::RGBObjectValue(const std::string& value)
     }
 }
 
-std::string RGBObjectValue::toString()
+std::string RGBObjectValue::toString() const
 {
     std::ostringstream out;
     out.setf(std::ios::hex, std::ios::basefield);
@@ -2356,7 +2356,7 @@ RGBWObjectValue::RGBWObjectValue(const std::string& value)
     }
 }
 
-std::string RGBWObjectValue::toString()
+std::string RGBWObjectValue::toString() const
 {
     std::ostringstream out;
     out.setf(std::ios::hex, std::ios::basefield);
@@ -2422,7 +2422,7 @@ IntObjectValue::IntObjectValue(const std::string& value)
     }
 }
 
-std::string IntObjectValue::toString()
+std::string IntObjectValue::toString() const
 {
     std::ostringstream out;
     out << value_m;
@@ -2520,7 +2520,7 @@ S8ObjectValue::S8ObjectValue(const std::string& value)
     }
 }
 
-std::string S8ObjectValue::toString()
+std::string S8ObjectValue::toString() const
 {
     std::ostringstream out;
     out << value_m;
@@ -2585,7 +2585,7 @@ S16ObjectValue::S16ObjectValue(const std::string& value)
     }
 }
 
-std::string S16ObjectValue::toString()
+std::string S16ObjectValue::toString() const
 {
     std::ostringstream out;
     out << value_m;
@@ -2645,7 +2645,7 @@ S32ObjectValue::S32ObjectValue(const std::string& value)
     }
 }
 
-std::string S32ObjectValue::toString()
+std::string S32ObjectValue::toString() const
 {
     std::ostringstream out;
     out << value_m;
@@ -2704,7 +2704,7 @@ S64ObjectValue::S64ObjectValue(const std::string& value)
     }
 }
 
-std::string S64ObjectValue::toString()
+std::string S64ObjectValue::toString() const
 {
     std::ostringstream out;
     out << value_m;
@@ -2824,7 +2824,7 @@ StringObjectValue::StringObjectValue(const std::string& value)
 //    logger_m.debugStream() << "StringObjectValue: Value: '" << value_m << "'" << endlog;
 }
 
-std::string StringObjectValue::toString()
+std::string StringObjectValue::toString() const
 {
     return value_m;
 }

--- a/src/objectcontroller.h
+++ b/src/objectcontroller.h
@@ -44,7 +44,7 @@ class ObjectValue
 {
 public:
     virtual ~ObjectValue() {};
-    virtual std::string toString() = 0;
+    virtual std::string toString() const = 0;
     virtual bool equals(ObjectValue* value) = 0;
     virtual int compare(ObjectValue* value) = 0;
     virtual bool set(ObjectValue* value) = 0;
@@ -240,10 +240,10 @@ public:
     void init (const std::string& value);
     virtual bool equals(ObjectValue* value);
     virtual int compare(ObjectValue* value);
-    virtual std::string toString();
+    virtual std::string toString() const;
     virtual double toNumber();
     virtual std::string getType() { return "1.001"; };
-    virtual std::string getValueString(bool value) { return value ? "on" : "off"; };
+    virtual std::string getValueString(bool value) const { return value ? "on" : "off"; };
 protected:
     SwitchingObjectValue() : value_m(false) {};
     virtual bool set(bool value);
@@ -283,7 +283,7 @@ public:
     SwitchingImplObjectValue(bool value) : SwitchingObjectValue(value) {};
     virtual ~SwitchingImplObjectValue() {};
     virtual std::string getType() { return SwitchingTypes[eis].type; };
-    virtual std::string getValueString(bool value) { return value ? SwitchingTypes[eis].valueTrue : SwitchingTypes[eis].valueFalse; };
+    virtual std::string getValueString(bool value) const { return value ? SwitchingTypes[eis].valueTrue : SwitchingTypes[eis].valueFalse; };
 };
 
 template <typename TObjectValue>
@@ -338,10 +338,10 @@ public:
     void init(const std::string& value);
     virtual bool equals(ObjectValue* value);
     virtual int compare(ObjectValue* value);
-    virtual std::string toString();
+    virtual std::string toString() const;
     virtual double toNumber();
     virtual std::string getType() { return "2.001"; };
-    virtual std::string getValueString(bool value) { return value ? "on" : "off"; };
+    virtual std::string getValueString(bool value) const { return value ? "on" : "off"; };
 protected:
     SwitchingControlObjectValue() : value_m(false), control_m(false) {};
     virtual bool set(bool value, bool control);
@@ -380,7 +380,7 @@ public:
     SwitchingControlImplObjectValue(bool value, bool control) : SwitchingControlObjectValue(value, control) {};
     virtual ~SwitchingControlImplObjectValue() {};
     virtual std::string getType() { return SwitchingControlTypes[eis].type; };
-    virtual std::string getValueString(bool value) { return value ? SwitchingControlTypes[eis].valueTrue : SwitchingControlTypes[eis].valueFalse; };
+    virtual std::string getValueString(bool value) const { return value ? SwitchingControlTypes[eis].valueTrue : SwitchingControlTypes[eis].valueFalse; };
 };
 
 class StepDirObjectValue : public ObjectValue
@@ -389,7 +389,7 @@ public:
     virtual ~StepDirObjectValue() {};
     virtual bool equals(ObjectValue* value);
     virtual int compare(ObjectValue* value);
-    virtual std::string toString() = 0;
+    virtual std::string toString() const = 0;
     virtual double toNumber();
 protected:
     virtual bool set(ObjectValue* value);
@@ -428,7 +428,7 @@ class DimmingObjectValue : public StepDirObjectValue
 public:
     DimmingObjectValue(const std::string& value);
     virtual ~DimmingObjectValue() {};
-    virtual std::string toString();
+    virtual std::string toString() const;
 protected:
     DimmingObjectValue(int direction, int stepcode) : StepDirObjectValue(direction, stepcode) {};
 };
@@ -457,7 +457,7 @@ class BlindsObjectValue : public StepDirObjectValue
 public:
     BlindsObjectValue(const std::string& value);
     virtual ~BlindsObjectValue() {};
-    virtual std::string toString();
+    virtual std::string toString() const;
 protected:
     BlindsObjectValue(int direction, int stepcode) : StepDirObjectValue(direction, stepcode) {};
 };
@@ -488,7 +488,7 @@ public:
     virtual ~TimeObjectValue() {};
     virtual bool equals(ObjectValue* value);
     virtual int compare(ObjectValue* value);
-    virtual std::string toString();
+    virtual std::string toString() const;
     virtual double toNumber();
     void getTimeValue(int *wday, int *hour, int *min, int *sec);
 protected:
@@ -531,7 +531,7 @@ public:
     virtual ~DateObjectValue() {};
     virtual bool equals(ObjectValue* value);
     virtual int compare(ObjectValue* value);
-    virtual std::string toString();
+    virtual std::string toString() const;
     virtual double toNumber();
     void getDateValue(int *day, int *month, int *year);
 protected:
@@ -574,7 +574,7 @@ public:
     void init(const std::string& value);
     virtual bool equals(ObjectValue* value);
     virtual int compare(ObjectValue* value);
-    virtual std::string toString();
+    virtual std::string toString() const;
     virtual double toNumber();
     virtual void setPrecision(std::string precision);
     virtual std::string getPrecision();
@@ -695,7 +695,7 @@ class ValueObject32Value : public ValueObjectValue
 public:
     ValueObject32Value(const std::string& value);
     virtual ~ValueObject32Value() {};
-    virtual std::string toString();
+    virtual std::string toString() const;
     virtual double roundToKnxPrecision(double value) { return value; };
     virtual std::string getType() { return "14.xxx"; };
     virtual double getBound(bool upper) { return upper ? DBL_MAX : DBL_MIN; };
@@ -735,7 +735,7 @@ public:
     virtual ~UIntObjectValue() {};
     virtual bool equals(ObjectValue* value);
     virtual int compare(ObjectValue* value);
-    virtual std::string toString();
+    virtual std::string toString() const;
     virtual double toNumber();
 protected:
     virtual bool set(ObjectValue* value);
@@ -771,7 +771,7 @@ class U8ObjectValue : public UIntObjectValue
 public:
     U8ObjectValue(const std::string& value);
     virtual ~U8ObjectValue() {};
-    virtual std::string toString();
+    virtual std::string toString() const;
 protected:
     U8ObjectValue(uint32_t value) : UIntObjectValue(value) {};
     U8ObjectValue() {};
@@ -801,7 +801,7 @@ public:
     virtual ObjectValue* createObjectValue(const std::string& value);
     virtual void setValue(const std::string& value);
     virtual std::string getType() { return "5.xxx"; };
-    virtual std::string toString() { return U8ObjectValue::toString(); };
+    virtual std::string toString() const { return U8ObjectValue::toString(); };
 protected:
     virtual bool set(ObjectValue* value) { return U8ObjectValue::set(value); };
     virtual bool setInt(uint32_t value) { if (value_m != value) { value_m = value; return true; } return false; };
@@ -824,7 +824,7 @@ class ScalingObjectValue : public U8ObjectValue
 public:
     ScalingObjectValue(const std::string& value);
     virtual ~ScalingObjectValue() {};
-    virtual std::string toString();
+    virtual std::string toString() const;
 protected:
     ScalingObjectValue(uint32_t value) : U8ObjectValue(value) {};
 };
@@ -838,7 +838,7 @@ public:
     virtual ObjectValue* createObjectValue(const std::string& value);
     virtual void setValue(const std::string& value);
     virtual std::string getType() { return "5.001"; };
-    virtual std::string toString() { return ScalingObjectValue::toString(); };
+    virtual std::string toString() const { return ScalingObjectValue::toString(); };
 protected:
     virtual bool set(ObjectValue* value) { return ScalingObjectValue::set(value); };
     virtual bool setInt(uint32_t value) { if (value_m != value) { value_m = value; return true; } return false; };
@@ -851,7 +851,7 @@ class AngleObjectValue : public U8ObjectValue
 {
 public:
     AngleObjectValue(const std::string& value);
-    virtual std::string toString();
+    virtual std::string toString() const;
 protected:
     AngleObjectValue(uint32_t value) : U8ObjectValue(value) {};
 };
@@ -865,7 +865,7 @@ public:
     virtual ObjectValue* createObjectValue(const std::string& value);
     virtual void setValue(const std::string& value);
     virtual std::string getType() { return "5.003"; };
-    virtual std::string toString() { return AngleObjectValue::toString(); };
+    virtual std::string toString() const { return AngleObjectValue::toString(); };
 protected:
     virtual bool set(ObjectValue* value) { return AngleObjectValue::set(value); };
     virtual bool setInt(uint32_t value) { if (value_m != value) { value_m = value; return true; } return false; };
@@ -878,7 +878,7 @@ class HeatingModeObjectValue : public U8ObjectValue
 {
 public:
     HeatingModeObjectValue(const std::string& value);
-    virtual std::string toString();
+    virtual std::string toString() const;
 protected:
     HeatingModeObjectValue() {};
     HeatingModeObjectValue(uint32_t value) : U8ObjectValue(value) {};
@@ -890,7 +890,7 @@ public:
     virtual ObjectValue* createObjectValue(const std::string& value);
     virtual void setValue(const std::string& value);
     virtual std::string getType() { return "20.102"; };
-    virtual std::string toString() { return HeatingModeObjectValue::toString(); };
+    virtual std::string toString() const { return HeatingModeObjectValue::toString(); };
 protected:
     virtual bool set(ObjectValue* value) { return HeatingModeObjectValue::set(value); };
     virtual bool setInt(uint32_t value) { if (value_m != value) { value_m = value; return true; } return false; };
@@ -903,7 +903,7 @@ class Latin1CharObjectValue : public U8ObjectValue
 {
 public:
     Latin1CharObjectValue(const std::string& value);
-    virtual std::string toString();
+    virtual std::string toString() const;
 protected:
     Latin1CharObjectValue(uint32_t value) : U8ObjectValue(value) {};
 };
@@ -912,7 +912,7 @@ class AsciiCharObjectValue : public U8ObjectValue
 {
 public:
     AsciiCharObjectValue(const std::string& value);
-    virtual std::string toString();
+    virtual std::string toString() const;
 protected:
     AsciiCharObjectValue(uint32_t value) : U8ObjectValue(value) {};
 };
@@ -926,7 +926,7 @@ public:
     virtual ObjectValue* createObjectValue(const std::string& value);
     virtual void setValue(const std::string& value);
     virtual std::string getType() { return "4.002"; };
-    virtual std::string toString() { return Latin1CharObjectValue::toString(); };
+    virtual std::string toString() const { return Latin1CharObjectValue::toString(); };
 protected:
     virtual bool set(ObjectValue* value) { return Latin1CharObjectValue::set(value); };
     virtual bool setInt(uint32_t value) { if (value_m != value) { value_m = value; return true; } return false; };
@@ -944,7 +944,7 @@ public:
     virtual ObjectValue* createObjectValue(const std::string& value);
     virtual void setValue(const std::string& value);
     virtual std::string getType() { return "4.001"; };
-    virtual std::string toString() { return AsciiCharObjectValue::toString(); };
+    virtual std::string toString() const { return AsciiCharObjectValue::toString(); };
 protected:
     virtual bool set(ObjectValue* value) { return AsciiCharObjectValue::set(value); };
     virtual bool setInt(uint32_t value) { if (value_m != value) { value_m = value; return true; } return false; };
@@ -958,7 +958,7 @@ class U16ObjectValue : public UIntObjectValue
 public:
     U16ObjectValue(const std::string& value);
     virtual ~U16ObjectValue() {};
-    virtual std::string toString();
+    virtual std::string toString() const;
 protected:
     U16ObjectValue(uint32_t value) : UIntObjectValue(value) {};
     U16ObjectValue() {};
@@ -975,7 +975,7 @@ public:
     virtual std::string getType() { return "7.xxx"; };
     virtual void doWrite(const uint8_t* buf, int len, eibaddr_t src);
     virtual void doSend(bool isWrite);
-    virtual std::string toString() { return U16ObjectValue::toString(); };
+    virtual std::string toString() const { return U16ObjectValue::toString(); };
 protected:
     virtual bool set(ObjectValue* value) { return U16ObjectValue::set(value); };
     virtual bool setInt(uint32_t value) { if (value_m != value) { value_m = value; return true; } return false; };
@@ -989,7 +989,7 @@ class U32ObjectValue : public UIntObjectValue
 public:
     U32ObjectValue(const std::string& value);
     virtual ~U32ObjectValue() {};
-    virtual std::string toString();
+    virtual std::string toString() const;
 protected:
     U32ObjectValue(uint32_t value) : UIntObjectValue(value) {};
     U32ObjectValue() {};
@@ -1006,7 +1006,7 @@ public:
     virtual std::string getType() { return "12.xxx"; };
     virtual void doWrite(const uint8_t* buf, int len, eibaddr_t src);
     virtual void doSend(bool isWrite);
-    virtual std::string toString() { return U32ObjectValue::toString(); };
+    virtual std::string toString() const { return U32ObjectValue::toString(); };
 protected:
     virtual bool set(ObjectValue* value) { return U32ObjectValue::set(value); };
     virtual bool setInt(uint32_t value) { if (value_m != value) { value_m = value; return true; } return false; };
@@ -1020,7 +1020,7 @@ class RGBObjectValue : public UIntObjectValue
 public:
     RGBObjectValue(const std::string& value);
     virtual ~RGBObjectValue() {};
-    virtual std::string toString();
+    virtual std::string toString() const;
 protected:
     RGBObjectValue(uint32_t value) : UIntObjectValue(value) {};
     RGBObjectValue() {};
@@ -1037,7 +1037,7 @@ public:
     virtual std::string getType() { return "232.600"; };
     virtual void doWrite(const uint8_t* buf, int len, eibaddr_t src);
     virtual void doSend(bool isWrite);
-    virtual std::string toString() { return RGBObjectValue::toString(); };
+    virtual std::string toString() const { return RGBObjectValue::toString(); };
 protected:
     virtual bool set(ObjectValue* value) { return RGBObjectValue::set(value); };
     virtual bool setInt(uint32_t value) { if (value_m != value) { value_m = value; return true; } return false; };
@@ -1053,7 +1053,7 @@ public:
     virtual ~IntObjectValue() {};
     virtual bool equals(ObjectValue* value);
     virtual int compare(ObjectValue* value);
-    virtual std::string toString();
+    virtual std::string toString() const;
     virtual double toNumber();
 protected:
     virtual bool set(ObjectValue* value);
@@ -1089,7 +1089,7 @@ class S8ObjectValue : public IntObjectValue
 public:
     S8ObjectValue(const std::string& value);
     virtual ~S8ObjectValue() {};
-    virtual std::string toString();
+    virtual std::string toString() const;
 protected:
     S8ObjectValue(int32_t value) : IntObjectValue(value) {};
     S8ObjectValue() {};
@@ -1106,7 +1106,7 @@ public:
     virtual std::string getType() { return "6.xxx"; };
     virtual void doWrite(const uint8_t* buf, int len, eibaddr_t src);
     virtual void doSend(bool isWrite);
-    virtual std::string toString() { return S8ObjectValue::toString(); };
+    virtual std::string toString() const { return S8ObjectValue::toString(); };
 protected:
     virtual bool set(ObjectValue* value) { return S8ObjectValue::set(value); };
     virtual bool setInt(int32_t value) { if (value_m != value) { value_m = value; return true; } return false; };
@@ -1120,7 +1120,7 @@ class S16ObjectValue : public IntObjectValue
 public:
     S16ObjectValue(const std::string& value);
     virtual ~S16ObjectValue() {};
-    virtual std::string toString();
+    virtual std::string toString() const;
 protected:
     S16ObjectValue(int32_t value) : IntObjectValue(value) {};
     S16ObjectValue() {};
@@ -1137,7 +1137,7 @@ public:
     virtual std::string getType() { return "8.xxx"; };
     virtual void doWrite(const uint8_t* buf, int len, eibaddr_t src);
     virtual void doSend(bool isWrite);
-    virtual std::string toString() { return S16ObjectValue::toString(); };
+    virtual std::string toString() const { return S16ObjectValue::toString(); };
 protected:
     virtual bool set(ObjectValue* value) { return S16ObjectValue::set(value); };
     virtual bool setInt(int32_t value) { if (value_m != value) { value_m = value; return true; } return false; };
@@ -1151,7 +1151,7 @@ class S32ObjectValue : public IntObjectValue
 public:
     S32ObjectValue(const std::string& value);
     virtual ~S32ObjectValue() {};
-    virtual std::string toString();
+    virtual std::string toString() const;
 protected:
     S32ObjectValue(int32_t value) : IntObjectValue(value) {};
     S32ObjectValue() {};
@@ -1168,7 +1168,7 @@ public:
     virtual std::string getType() { return "13.xxx"; };
     virtual void doWrite(const uint8_t* buf, int len, eibaddr_t src);
     virtual void doSend(bool isWrite);
-    virtual std::string toString() { return S32ObjectValue::toString(); };
+    virtual std::string toString() const { return S32ObjectValue::toString(); };
 protected:
     virtual bool set(ObjectValue* value) { return S32ObjectValue::set(value); };
     virtual bool setInt(int32_t value) { if (value_m != value) { value_m = value; return true; } return false; };
@@ -1185,7 +1185,7 @@ public:
     virtual ~S64ObjectValue() {};
     virtual bool equals(ObjectValue* value);
     virtual int compare(ObjectValue* value);
-    virtual std::string toString();
+    virtual std::string toString() const;
     virtual double toNumber();
 protected:
     virtual bool set(ObjectValue* value);
@@ -1222,7 +1222,7 @@ class RGBWObjectValue : public S64ObjectValue
 public:
     RGBWObjectValue(const std::string& value);
     virtual ~RGBWObjectValue() {};
-    virtual std::string toString();
+    virtual std::string toString() const;
 protected:
     RGBWObjectValue(int64_t value) : S64ObjectValue(value) {};
     RGBWObjectValue() {};
@@ -1239,7 +1239,7 @@ public:
     virtual std::string getType() { return "251.600"; };
     virtual void doWrite(const uint8_t* buf, int len, eibaddr_t src);
     virtual void doSend(bool isWrite);
-    virtual std::string toString() { return RGBWObjectValue::toString(); };
+    virtual std::string toString() const { return RGBWObjectValue::toString(); };
 protected:
     virtual bool set(ObjectValue* value) { return RGBWObjectValue::set(value); };
     virtual bool setInt(int64_t value) { if (RGBWObjectValue::value_m != value) { RGBWObjectValue::value_m = value; return true; } return false; };
@@ -1256,7 +1256,7 @@ public:
     virtual ~StringObjectValue() {};
     virtual bool equals(ObjectValue* value);
     virtual int compare(ObjectValue* value);
-    virtual std::string toString();
+    virtual std::string toString() const;
     virtual double toNumber();
 
 	static std::string transcode(const std::string &source, const std::string &sourceEncoding, const std::string &targetEncoding);
@@ -1283,7 +1283,7 @@ public:
 
     virtual void doWrite(const uint8_t* buf, int len, eibaddr_t src);
     virtual void doSend(bool isWrite);
-    virtual std::string toString() { return StringObjectValue::toString(); };
+    virtual std::string toString() const { return StringObjectValue::toString(); };
 protected:
     virtual bool set(ObjectValue* value) { return StringObjectValue::set(value); };
     virtual bool set(double value) { return StringObjectValue::set(value); };
@@ -1321,7 +1321,7 @@ public:
 
     virtual void doWrite(const uint8_t* buf, int len, eibaddr_t src);
     virtual void doSend(bool isWrite);
-    virtual std::string toString() { return String14ObjectValue::toString(); };
+    virtual std::string toString() const { return String14ObjectValue::toString(); };
 protected:
     virtual bool set(ObjectValue* value) { return String14ObjectValue::set(value); };
     virtual bool set(double value) { return String14ObjectValue::set(value); };
@@ -1343,7 +1343,7 @@ public:
 
     virtual void doWrite(const uint8_t* buf, int len, eibaddr_t src);
     virtual void doSend(bool isWrite);
-    virtual std::string toString() { return String14AsciiObjectValue::toString(); };
+    virtual std::string toString() const { return String14AsciiObjectValue::toString(); };
 protected:
     virtual bool set(ObjectValue* value) { return String14AsciiObjectValue::set(value); };
     virtual bool set(double value) { return String14AsciiObjectValue::set(value); };

--- a/src/persistentstorage.cpp
+++ b/src/persistentstorage.cpp
@@ -109,9 +109,9 @@ std::string FilePersistentStorage::read(const std::string& id, const std::string
     return value;
 }
 
-void FilePersistentStorage::writelog(const std::string& id, const std::string& value)
+void FilePersistentStorage::writelog(const std::string &id, const ObjectValue &value)
 {
-    logger_m.infoStream() << "Writing log'" << value << "' for object '" << id << "'" << endlog;
+    logger_m.infoStream() << "Writing log'" << value.toString() << "' for object '" << id << "'" << endlog;
     std::string filename = logPath_m+id+".log";
     std::ofstream fp_out(filename.c_str(), std::ios::app);
 
@@ -123,7 +123,7 @@ void FilePersistentStorage::writelog(const std::string& id, const std::string& v
     << timeinfo->tm_hour << ":" << std::setfill('0') << std::setw(2)
     << timeinfo->tm_min << ":" << std::setfill('0') << std::setw(2)
     << timeinfo->tm_sec;
-    fp_out << " > " << value << "\n";
+    fp_out << " > " << value.toString() << "\n";
     fp_out.close(); 
 }
 
@@ -243,14 +243,14 @@ std::string MysqlPersistentStorage::read(const std::string& id, const std::strin
     return value;
 }
 
-void MysqlPersistentStorage::writelog(const std::string& id, const std::string& value)
+void MysqlPersistentStorage::writelog(const std::string &id, const ObjectValue &value)
 {
     if (logtable_m == "")
         return;
-    logger_m.infoStream() << "Writing log '" << value << "' for object '" << id << "'" << endlog;
+    logger_m.infoStream() << "Writing log '" << value.toString() << "' for object '" << id << "'" << endlog;
 
     std::stringstream sql;
-    sql << "INSERT INTO `" << logtable_m << "` (ts, object, value) VALUES (NOW(), '" << id << "', '" << value << "');";
+    sql << "INSERT INTO `" << logtable_m << "` (ts, object, value) VALUES (NOW(), '" << id << "', '" << value.toString() << "');";
 
     if (mysql_real_query(&con_m, sql.str().c_str(), sql.str().length()) != 0)
     {

--- a/src/persistentstorage.h
+++ b/src/persistentstorage.h
@@ -24,6 +24,7 @@
 #include "config.h"
 #include "logger.h"
 #include "ticpp.h"
+#include "objectcontroller.h"
 
 #ifdef HAVE_MYSQL
 #include <mysql/mysql.h>
@@ -40,7 +41,7 @@ public:
 
     virtual void write(const std::string& id, const std::string& value) = 0;
     virtual std::string read(const std::string& id, const std::string& defval="") = 0;
-    virtual void writelog(const std::string& id, const std::string& value) = 0;
+    virtual void writelog(const std::string &id, const ObjectValue &value) = 0;
 };
 
 class FilePersistentStorage : public PersistentStorage
@@ -53,7 +54,7 @@ public:
 
     virtual void write(const std::string& id, const std::string& value);
     virtual std::string read(const std::string& id, const std::string& defval="");
-    virtual void writelog(const std::string& id, const std::string& value);
+    virtual void writelog(const std::string& id, const ObjectValue &value);
 private:
     std::string path_m;
     std::string logPath_m;
@@ -72,7 +73,7 @@ public:
 
     virtual void write(const std::string& id, const std::string& value);
     virtual std::string read(const std::string& id, const std::string& defval="");
-    virtual void writelog(const std::string& id, const std::string& value);
+    virtual void writelog(const std::string& id, const ObjectValue &value);
 private:
     MYSQL con_m;
 


### PR DESCRIPTION
Instead of giving it the formatted string, pass it the full object value so that it can build the value that fits its need.
This is a preliminary PR to help @fraxinas rework #51. The goal is to avoid to store storage-specific logic in `Object` or `ObjectValue`.