### PR TITLE
Allow to run the worflow manually

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches: [ master ]
 
+  workflow_dispatch:
+
 env:
   # Force timezone to central european or unit tests checking DST/standard time switches will fail (those switches do not occur at the same time in all timezones).
   TZ: CET


### PR DESCRIPTION
Build on a master is suspected to be broken at the moment. But it is not possible to run the c-cpp workflow manually to double check, so this an attempt to fix that.