### PR TITLE
update configure.ac to deal with new libesmtp release

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -88,6 +88,8 @@ if test x"$enable_smtp" != xno ; then
 	)
 fi
 
+# first check for the new generation of libesmtp >= v1.1.0
+# this version provides a pkgconfig file named libesmtp-1.0.pc
 AC_MSG_CHECKING(whether to use libesmtp >= v1.1.x)
 if test x"$enable_smtp" != xno ; then
 	PKG_CHECK_MODULES(ESMTP, libesmtp-1.0 >= 1.1.0, [
@@ -103,6 +105,8 @@ if test x"$enable_smtp" != xno ; then
 		AC_MSG_RESULT([no])
 	])
 fi
+# if libesmtp >= 1.1.0 is not found: fallback to check for libesmtp < v1.1.0
+# which provides no pkgconfig file but the libesmtp-config utility
 if test x"$found_esmtp" = x ; then
 	AC_MSG_CHECKING(whether to use libesmtp v1.0.x)
 	if test x"$enable_smtp" != xno && test x`which libesmtp-config` != x ; then

--- a/configure.ac
+++ b/configure.ac
@@ -88,24 +88,41 @@ if test x"$enable_smtp" != xno ; then
 	)
 fi
 
-AC_MSG_CHECKING(whether to use libesmtp)
+AC_MSG_CHECKING(whether to use libesmtp >= v1.1.x)
 if test x"$enable_smtp" != xno ; then
-	ESMTP_CFLAGS="`libesmtp-config --cflags`"
-	ESMTP_LIBS="`libesmtp-config --libs`"
-	if test x"`libesmtp-config --libs | grep pthread`" != x ; then
-		AC_MSG_WARN([libesmtp is compiled with pthread support. This can conflict with pth. If you observe segmentation faults at startup, try to recompile with libesmtp support disabled])
-		AC_DEFINE([HAVE_LIBESMTP_PTHREAD], [1], [libesmtp is compiled with pthread support.])
-	fi
-	CFLAGS="$ESMTP_CFLAGS $CFLAGS"
-	if test x"$enable_smtp" = xstatic ; then
-		LIBS=`echo $ESMTP_LIBS $LIBS | sed 's/-lesmtp/-Xlinker -Bstatic -lesmtp -Xlinker -Bdynamic/'`
+	PKG_CHECK_MODULES(ESMTP, libesmtp-1.0 >= 1.1.0, [
+		AC_DEFINE([HAVE_LIBESMTP], [1], [Build with libesmtp email support.])
+		AC_SUBST(ESMTP_CFLAGS)
+		AC_SUBST(ESMTP_LIBS)
+		if test x"`echo $ESMTP_LIBS | grep pthread`" != x ; then
+			AC_MSG_WARN([libesmtp is compiled with pthread support. This can conflict with pth. If you observe segmentation faults at startup, try to recompile with libesmtp support disabled])
+			AC_DEFINE([HAVE_LIBESMTP_PTHREAD], [1], [libesmtp is compiled with pthread support.])
+		fi
+		found_esmtp=yes
+	],[
+		AC_MSG_RESULT([no])
+	])
+fi
+if test x"$found_esmtp" = x ; then
+	AC_MSG_CHECKING(whether to use libesmtp v1.0.x)
+	if test x"$enable_smtp" != xno && test x`which libesmtp-config` != x ; then
+		ESMTP_CFLAGS="`libesmtp-config --cflags`"
+		ESMTP_LIBS="`libesmtp-config --libs`"
+		if test x"`libesmtp-config --libs | grep pthread`" != x ; then
+			AC_MSG_WARN([libesmtp is compiled with pthread support. This can conflict with pth. If you observe segmentation faults at startup, try to recompile with libesmtp support disabled])
+			AC_DEFINE([HAVE_LIBESMTP_PTHREAD], [1], [libesmtp is compiled with pthread support.])
+		fi
+		CFLAGS="$ESMTP_CFLAGS $CFLAGS"
+		if test x"$enable_smtp" = xstatic ; then
+			LIBS=`echo $ESMTP_LIBS $LIBS | sed 's/-lesmtp/-Xlinker -Bstatic -lesmtp -Xlinker -Bdynamic/'`
+		else
+			LIBS="$ESMTP_LIBS $LIBS"
+		fi
+		AC_DEFINE([HAVE_LIBESMTP], [1], [Build with libesmtp email support.])
+		AC_MSG_RESULT([yes])
 	else
-		LIBS="$ESMTP_LIBS $LIBS"
+		AC_MSG_RESULT([no])
 	fi
-	AC_DEFINE([HAVE_LIBESMTP], [1], [Build with libesmtp email support.])
-	AC_MSG_RESULT([yes])
-else
-	AC_MSG_RESULT([no])
 fi
 AM_CONDITIONAL([USE_B64], [test x"$enable_smtp" != xno])
 


### PR DESCRIPTION
Signed-off-by: Othmar Truniger <github@truniger.ch>

This patch prepares for new version of libesmtp-1.1.0 which dropped the libesmtp-config script in favor of a pkgconfig file.
The configure script now first checks for the new libesmtp version using pkgconfig file and only if this is not found it will further check for the old version as before.

Please consider releasing a new version once this patch is accepted in order to support clean cross compilation with a new official tarball.